### PR TITLE
Add application properties and schema file

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=AccountWS

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,17 @@
+server:
+  port: 8080
+
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: dgatla
+    password: ''
+  h2:
+    console:
+      enabled: true
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: update
+    show-sql: true

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS `customer`(
+    `customer_id` int AUTO_INCREMENT PRIMARY KEY,
+    `name` varchar(100) NOT NULL,
+    `email` varchar(100) NOT NULL,
+    `mobile_number` varchar(10) NOT NULL,
+    `create_dt` date not NULL,
+    `created_by` varchar(20) NOT NULL,
+    `updated_at` timestamp NOT NULL,
+    `updated_by` varchar(20) NOT NULL
+);


### PR DESCRIPTION
I have added the application.yml file. This points the app to use the H2 DB.

Server port 8080: This is a standard port for web applications. It's widely recognized and doesn't conflict with common system ports, making it a good default choice.

H2 in-memory database: The datasource URL "jdbc:h2:mem:testdb" sets up an H2 database that runs in memory. This is excellent for development and testing as it's fast, doesn't require external setup, and resets with each application restart.

Database username and password: The username "dgatla" is likely a developer or project-specific choice. The empty password is fine for a development environment, though you'd want to change this for production.

H2 console enabled: This allows easy database inspection during development, which is very helpful for debugging and verifying data.

JPA configurations:

H2Dialect ensures Hibernate generates appropriate SQL for the H2 database.
"ddl-auto: update" automatically updates the database schema based on entity classes, saving time during development.
"show-sql: true" logs SQL statements, which is invaluable for debugging database interactions.


And regarding the schema.sql it is used to define or create the table and to add the data create data.sql