### PR TITLE
Update create_dt column to created_at for more consistency

### DIFF
--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -3,7 +3,7 @@ CREATE TABLE IF NOT EXISTS `customers`(
     `name` varchar(100) NOT NULL,
     `email` varchar(100) NOT NULL,
     `mobile_number` varchar(10) NOT NULL,
-    `create_dt` date not NULL,
+    `created_at` timestamp not NULL,
     `created_by` varchar(20) NOT NULL,
     `updated_at` timestamp NOT NULL,
     `updated_by` varchar(20) NOT NULL
@@ -15,7 +15,7 @@ CREATE TABLE IF NOT EXISTS `accounts`(
      `account_id` int AUTO_INCREMENT PRIMARY KEY,
      `account_type` varchar(20) NOT NULL,
      `branch_address` varchar(100) NOT NULL,
-     `create_dt` timestamp not NULL,
+     `created_at` timestamp not NULL,
      `created_by` varchar(20) NOT NULL,
      `updated_at` timestamp NOT NULL,
      `updated_by` varchar(20) NOT NULL


### PR DESCRIPTION
```
`created_at` is more used and is a good practice. I am using a timestamp instead of date as that makes more sense since we are storing when the value was created.

`updated_at` is already storing timestamps so no need to change it.
```