### PR TITLE
add-repositories

### DIFF
--- a/src/main/java/com/dinesh/accountws/repository/AccountRepository.java
+++ b/src/main/java/com/dinesh/accountws/repository/AccountRepository.java
@@ -1,0 +1,9 @@
+package com.dinesh.accountws.repository;
+
+import com.dinesh.accountws.models.Account;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AccountRepository extends JpaRepository<Account, Long> {
+}

--- a/src/main/java/com/dinesh/accountws/repository/CustomerRepository.java
+++ b/src/main/java/com/dinesh/accountws/repository/CustomerRepository.java
@@ -1,0 +1,9 @@
+package com.dinesh.accountws.repository;
+
+import com.dinesh.accountws.models.Customer;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CustomerRepository extends JpaRepository<Customer, Long> {
+}


### PR DESCRIPTION
Add repository classes for Customer and Accounts.

In Spring Boot, the `@Repository` annotation is used to indicate that a particular class is a "Repository" in the persistence layer. It is a specialization of the `@Component` annotation, which means that it is a candidate for component scanning and Spring will automatically detect it and register it as a bean in the application context.

---

The `@Repository` annotation is typically used to define Data Access Objects (DAOs).

---

### When to Use
Use the `@Repository` annotation when you are creating a class or interface that will directly interact with the database, such as performing `CRUD` operations or executing queries. It is part of the standard pattern for separating the persistence logic from the business logic in a Spring application.